### PR TITLE
Do not update uuids

### DIFF
--- a/api/src/main/java/org/openmrs/module/oauth2login/authscheme/UpdateUserTask.java
+++ b/api/src/main/java/org/openmrs/module/oauth2login/authscheme/UpdateUserTask.java
@@ -7,7 +7,6 @@ import java.util.stream.Collectors;
 import org.apache.commons.beanutils.BeanUtilsBean;
 import org.openmrs.User;
 import org.openmrs.api.UserService;
-import org.openmrs.module.oauth2login.OAuth2LoginConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeanWrapperImpl;


### PR DESCRIPTION
When updating a user from SSO info, user's uuid was also updated. 
I modified BeanUtilsBean to avoid synchronizing uuids.