### PR TITLE
OA-39: Resolve environment variables in OAuth2 properties

### DIFF
--- a/omod/src/test/java/org/openmrs/module/oauth2login/web/controller/OAuth2BeanFactoryTest.java
+++ b/omod/src/test/java/org/openmrs/module/oauth2login/web/controller/OAuth2BeanFactoryTest.java
@@ -18,22 +18,46 @@ public class OAuth2BeanFactoryTest {
 	
 	@Test
 	public void resolveEnvVariables_shouldReturnResolvedValue() {
-		String value = "Database URL: ${DB_URL}";
-		System.setProperty("DB_URL", "jdbc:mysql://localhost:3306/openmrs");
+		String value = "Authorization URL: ${OAUTH_URL}";
+		System.setProperty("OAUTH_URL", "https://localhost:8080/auth");
 		
 		String resolvedValue = OAuth2BeanFactory.resolveEnvVariables(value);
 		
 		assertNotNull(resolvedValue);
-		assertEquals("Database URL: jdbc:mysql://localhost:3306/openmrs", resolvedValue);
+		assertEquals("Authorization URL: https://localhost:8080/auth", resolvedValue);
+	}
+	
+	@Test
+	public void resolveEnvVariables_shouldReturnResolvedValueWithMultipleEnvVariables() {
+		String value = "Authorization URL: ${OAUTH_URL}, Client Secret: ${CLIENT_SECRET}";
+		System.setProperty("OAUTH_URL", "https://localhost:8080/auth");
+		System.setProperty("CLIENT_SECRET", "secret");
+		
+		String resolvedValue = OAuth2BeanFactory.resolveEnvVariables(value);
+		
+		assertNotNull(resolvedValue);
+		assertEquals("Authorization URL: https://localhost:8080/auth, Client Secret: secret", resolvedValue);
+	}
+	
+	@Test
+	public void resolveEnvVariables_shouldReturnResolvedValueWithMultipleOccurrencesOfEnvVariable() {
+		String value = "Authorization URL: ${OAUTH_URL}, Authorization URL: ${OAUTH_URL}";
+		System.setProperty("OAUTH_URL", "https://localhost:8080/auth");
+		
+		String resolvedValue = OAuth2BeanFactory.resolveEnvVariables(value);
+		
+		assertNotNull(resolvedValue);
+		assertEquals("Authorization URL: https://localhost:8080/auth, Authorization URL: https://localhost:8080/auth",
+		    resolvedValue);
 	}
 	
 	@Test
 	public void resolveEnvVariables_shouldReturnOriginalValueIfNoEnvVariable() {
-		String value = "Database URL: ${DB_URL}";
+		String value = "Authorization URL: ${OAUTH_URL}";
 		
 		String resolvedValue = OAuth2BeanFactory.resolveEnvVariables(value);
 		
 		assertNotNull(resolvedValue);
-		assertEquals("Database URL: ${DB_URL}", resolvedValue);
+		assertEquals("Authorization URL: ${OAUTH_URL}", resolvedValue);
 	}
 }

--- a/omod/src/test/java/org/openmrs/module/oauth2login/web/controller/OAuth2BeanFactoryTest.java
+++ b/omod/src/test/java/org/openmrs/module/oauth2login/web/controller/OAuth2BeanFactoryTest.java
@@ -1,0 +1,39 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.oauth2login.web.controller;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class OAuth2BeanFactoryTest {
+	
+	@Test
+	public void resolveEnvVariables_shouldReturnResolvedValue() {
+		String value = "Database URL: ${DB_URL}";
+		System.setProperty("DB_URL", "jdbc:mysql://localhost:3306/openmrs");
+		
+		String resolvedValue = OAuth2BeanFactory.resolveEnvVariables(value);
+		
+		assertNotNull(resolvedValue);
+		assertEquals("Database URL: jdbc:mysql://localhost:3306/openmrs", resolvedValue);
+	}
+	
+	@Test
+	public void resolveEnvVariables_shouldReturnOriginalValueIfNoEnvVariable() {
+		String value = "Database URL: ${DB_URL}";
+		
+		String resolvedValue = OAuth2BeanFactory.resolveEnvVariables(value);
+		
+		assertNotNull(resolvedValue);
+		assertEquals("Database URL: ${DB_URL}", resolvedValue);
+	}
+}

--- a/omod/src/test/java/org/openmrs/module/oauth2login/web/filter/OAuth2ServiceAccountFilterTest.java
+++ b/omod/src/test/java/org/openmrs/module/oauth2login/web/filter/OAuth2ServiceAccountFilterTest.java
@@ -137,8 +137,8 @@ public class OAuth2ServiceAccountFilterTest {
 		Context.authenticate(mockCredentials);
 		Assert.assertEquals("The initial properties object should not be changed for username", propNameThatWontBeUsed,
 		    props.get(UserInfo.PROP_USERNAME));
-		Assert.assertEquals("The cloned properties will be changed for username property",
-		    propNameThatWillBeUsed, clonedProperties.get(UserInfo.PROP_USERNAME));
+		Assert.assertEquals("The cloned properties will be changed for username property", propNameThatWillBeUsed,
+		    clonedProperties.get(UserInfo.PROP_USERNAME));
 	}
 	
 	@Test


### PR DESCRIPTION
Issue: https://openmrs.atlassian.net/browse/OA-39

This PR adds the ability to resolve environment variables placeholders to the their corresponding environment variables at runtime.