### PR TITLE
OA-40: Add property to control starting of the module

### DIFF
--- a/api/src/main/java/org/openmrs/module/oauth2login/OAuth2LoginConstants.java
+++ b/api/src/main/java/org/openmrs/module/oauth2login/OAuth2LoginConstants.java
@@ -27,4 +27,6 @@ public class OAuth2LoginConstants {
 	
 	public static final String USER_PROP_ID_TOKEN = "oauth2IdToken";
 	
+	public static final String OAUTH2_ENABLED_PROPERTY = "oauth2.enabled";
+	
 }

--- a/api/src/main/java/org/openmrs/module/oauth2login/PropertyUtils.java
+++ b/api/src/main/java/org/openmrs/module/oauth2login/PropertyUtils.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.oauth2login;
 
 import org.apache.commons.logging.Log;

--- a/api/src/main/java/org/openmrs/module/oauth2login/PropertyUtils.java
+++ b/api/src/main/java/org/openmrs/module/oauth2login/PropertyUtils.java
@@ -1,0 +1,69 @@
+package org.openmrs.module.oauth2login;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.util.OpenmrsUtil;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class PropertyUtils {
+	
+	protected static final Log LOG = LogFactory.getLog(PropertyUtils.class);
+	
+	private static final Pattern ENV_PATTERN = Pattern.compile("\\$\\{([^}]+)}");
+	
+	public static Properties getProperties(Path path) throws IOException {
+        Properties props = new Properties();
+        try (InputStream inputStream = Files.newInputStream(path)) {
+            props.load(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+            for (String key : props.stringPropertyNames()) {
+                String value = props.getProperty(key);
+                props.setProperty(key, resolveEnvVariables(value));
+            }
+        }
+        return props;
+    }
+	
+	/**
+	 * Resolves environment variables in the given string.
+	 * <p>
+	 * This method searches for placeholders in the format ${ENV_VAR} within the input string and
+	 * replaces them with the corresponding environment variable values. It first checks system
+	 * properties and then environment variables for the value of each placeholder.
+	 * 
+	 * @param value the input string containing placeholders for environment variables
+	 * @return the input string with all environment variables resolved
+	 */
+	public static String resolveEnvVariables(String value) {
+		Matcher matcher = ENV_PATTERN.matcher(value);
+		StringBuffer buffer = new StringBuffer();
+		while (matcher.find()) {
+			String envVar = matcher.group(1);
+			String envValue = System.getProperty(envVar, System.getenv(envVar));
+			matcher.appendReplacement(buffer, Matcher.quoteReplacement(envValue != null ? envValue : matcher.group(0)));
+		}
+		matcher.appendTail(buffer);
+		return buffer.toString();
+	}
+	
+	public static Path getOAuth2PropertiesPath() {
+		Path path = Paths.get(OpenmrsUtil.getApplicationDataDirectory(), "oauth2.properties");
+		if (!path.toFile().exists()) {
+			LOG.error("the property file doesn't exist " + path.toAbsolutePath());
+		}
+		return path;
+	}
+	
+	public static Properties getOAuth2Properties() throws IOException {
+		return getProperties(getOAuth2PropertiesPath());
+	}
+}

--- a/api/src/test/java/org/openmrs/module/oauth2login/OAuth2LoginActivatorTest.java
+++ b/api/src/test/java/org/openmrs/module/oauth2login/OAuth2LoginActivatorTest.java
@@ -1,0 +1,99 @@
+package org.openmrs.module.oauth2login;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openmrs.module.ModuleException;
+import org.openmrs.module.ModuleFactory;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import static org.mockito.Mockito.times;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ PropertyUtils.class, ModuleFactory.class })
+public class OAuth2LoginActivatorTest {
+	
+	private OAuth2LoginActivator activator;
+	
+	@Before
+	public void setup() {
+		activator = new OAuth2LoginActivator();
+		PowerMockito.mockStatic(PropertyUtils.class);
+		PowerMockito.mockStatic(ModuleFactory.class);
+	}
+	
+	@Test
+	public void willStart_shouldStopAndUnloadModuleIfOAuth2IsDisabled() throws IOException {
+		// Setup
+		Properties mockProperties = mock(Properties.class);
+		when(mockProperties.getProperty(OAuth2LoginConstants.OAUTH2_ENABLED_PROPERTY, "true")).thenReturn("false");
+		when(PropertyUtils.getOAuth2Properties()).thenReturn(mockProperties);
+		
+		// Replay
+		activator.willStart();
+		
+		// Verify
+		verifyStatic(times(1));
+		ModuleFactory.stopModule(ModuleFactory.getModuleById(OAuth2LoginConstants.MODULE_ARTIFACT_ID));
+		
+		verifyStatic(times(1));
+		ModuleFactory.unloadModule(ModuleFactory.getModuleById(OAuth2LoginConstants.MODULE_ARTIFACT_ID));
+	}
+	
+	@Test
+	public void willStart_shouldStartModuleIfOAuth2IsEnabled() throws IOException {
+		// Setup
+		Properties mockProperties = mock(Properties.class);
+		when(mockProperties.getProperty(OAuth2LoginConstants.OAUTH2_ENABLED_PROPERTY, "true")).thenReturn("true");
+		when(PropertyUtils.getOAuth2Properties()).thenReturn(mockProperties);
+		
+		// Replay
+		activator.willStart();
+		
+		// Verify
+		verifyStatic(times(0));
+		ModuleFactory.stopModule(ModuleFactory.getModuleById(OAuth2LoginConstants.MODULE_ARTIFACT_ID));
+		
+		verifyStatic(times(0));
+		ModuleFactory.unloadModule(ModuleFactory.getModuleById(OAuth2LoginConstants.MODULE_ARTIFACT_ID));
+	}
+	
+	@Test
+	public void willStart_shouldStopAndUnloadModuleIfModuleIsAlreadyStarted() throws IOException {
+		// Setup
+		Properties mockProperties = mock(Properties.class);
+		when(mockProperties.getProperty(OAuth2LoginConstants.OAUTH2_ENABLED_PROPERTY, "true")).thenReturn("false");
+		when(PropertyUtils.getOAuth2Properties()).thenReturn(mockProperties);
+		when(ModuleFactory.isModuleStarted(OAuth2LoginConstants.MODULE_ARTIFACT_ID)).thenReturn(true);
+		
+		// Replay
+		activator.willStart();
+		
+		// Verify
+		verifyStatic(times(1));
+		ModuleFactory.isModuleStarted(OAuth2LoginConstants.MODULE_ARTIFACT_ID);
+		
+		verifyStatic(times(2));
+		ModuleFactory.stopModule(ModuleFactory.getModuleById(OAuth2LoginConstants.MODULE_ARTIFACT_ID));
+		
+		verifyStatic(times(2));
+		ModuleFactory.unloadModule(ModuleFactory.getModuleById(OAuth2LoginConstants.MODULE_ARTIFACT_ID));
+	}
+	
+	@Test(expected = ModuleException.class)
+	public void willStart_shouldThrowModuleExceptionIfPropertiesFileCannotBeLoaded() throws IOException {
+		OAuth2LoginActivator activator = new OAuth2LoginActivator();
+		PropertyUtils propertyUtils = mock(PropertyUtils.class);
+		when(PropertyUtils.getOAuth2Properties()).thenThrow(new IOException());
+		
+		activator.willStart();
+	}
+}

--- a/api/src/test/java/org/openmrs/module/oauth2login/OAuth2LoginActivatorTest.java
+++ b/api/src/test/java/org/openmrs/module/oauth2login/OAuth2LoginActivatorTest.java
@@ -50,10 +50,10 @@ public class OAuth2LoginActivatorTest {
 		activator.willStart();
 		
 		// Verify
-		verifyStatic(times(1));
+		verifyStatic();
 		ModuleFactory.stopModule(ModuleFactory.getModuleById(OAuth2LoginConstants.MODULE_ARTIFACT_ID));
 		
-		verifyStatic(times(1));
+		verifyStatic();
 		ModuleFactory.unloadModule(ModuleFactory.getModuleById(OAuth2LoginConstants.MODULE_ARTIFACT_ID));
 	}
 	
@@ -87,7 +87,7 @@ public class OAuth2LoginActivatorTest {
 		activator.willStart();
 		
 		// Verify
-		verifyStatic(times(1));
+		verifyStatic();
 		ModuleFactory.isModuleStarted(OAuth2LoginConstants.MODULE_ARTIFACT_ID);
 		
 		verifyStatic(times(2));

--- a/api/src/test/java/org/openmrs/module/oauth2login/OAuth2LoginActivatorTest.java
+++ b/api/src/test/java/org/openmrs/module/oauth2login/OAuth2LoginActivatorTest.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.oauth2login;
 
 import org.junit.Before;

--- a/api/src/test/java/org/openmrs/module/oauth2login/PropertyUtilsTest.java
+++ b/api/src/test/java/org/openmrs/module/oauth2login/PropertyUtilsTest.java
@@ -1,3 +1,12 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.oauth2login;
 
 import org.junit.Test;

--- a/api/src/test/java/org/openmrs/module/oauth2login/PropertyUtilsTest.java
+++ b/api/src/test/java/org/openmrs/module/oauth2login/PropertyUtilsTest.java
@@ -1,27 +1,18 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public License,
- * v. 2.0. If a copy of the MPL was not distributed with this file, You can
- * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
- * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
- *
- * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
- * graphic logo is a trademark of OpenMRS Inc.
- */
-package org.openmrs.module.oauth2login.web.controller;
+package org.openmrs.module.oauth2login;
 
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-public class OAuth2BeanFactoryTest {
+public class PropertyUtilsTest {
 	
 	@Test
 	public void resolveEnvVariables_shouldReturnResolvedValue() {
 		String value = "Authorization URL: ${OAUTH_URL}";
 		System.setProperty("OAUTH_URL", "https://localhost:8080/auth");
 		
-		String resolvedValue = OAuth2BeanFactory.resolveEnvVariables(value);
+		String resolvedValue = PropertyUtils.resolveEnvVariables(value);
 		
 		assertNotNull(resolvedValue);
 		assertEquals("Authorization URL: https://localhost:8080/auth", resolvedValue);
@@ -33,7 +24,7 @@ public class OAuth2BeanFactoryTest {
 		System.setProperty("OAUTH_URL", "https://localhost:8080/auth");
 		System.setProperty("CLIENT_SECRET", "secret");
 		
-		String resolvedValue = OAuth2BeanFactory.resolveEnvVariables(value);
+		String resolvedValue = PropertyUtils.resolveEnvVariables(value);
 		
 		assertNotNull(resolvedValue);
 		assertEquals("Authorization URL: https://localhost:8080/auth, Client Secret: secret", resolvedValue);
@@ -44,7 +35,7 @@ public class OAuth2BeanFactoryTest {
 		String value = "Authorization URL: ${OAUTH_URL}, Authorization URL: ${OAUTH_URL}";
 		System.setProperty("OAUTH_URL", "https://localhost:8080/auth");
 		
-		String resolvedValue = OAuth2BeanFactory.resolveEnvVariables(value);
+		String resolvedValue = PropertyUtils.resolveEnvVariables(value);
 		
 		assertNotNull(resolvedValue);
 		assertEquals("Authorization URL: https://localhost:8080/auth, Authorization URL: https://localhost:8080/auth",
@@ -55,7 +46,7 @@ public class OAuth2BeanFactoryTest {
 	public void resolveEnvVariables_shouldReturnOriginalValueIfNoEnvVariable() {
 		String value = "Authorization URL: ${OAUTH_URL}";
 		
-		String resolvedValue = OAuth2BeanFactory.resolveEnvVariables(value);
+		String resolvedValue = PropertyUtils.resolveEnvVariables(value);
 		
 		assertNotNull(resolvedValue);
 		assertEquals("Authorization URL: ${OAUTH_URL}", resolvedValue);

--- a/omod/src/main/java/org/openmrs/module/oauth2login/web/controller/CustomLogoutSuccessHandler.java
+++ b/omod/src/main/java/org/openmrs/module/oauth2login/web/controller/CustomLogoutSuccessHandler.java
@@ -21,6 +21,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.oauth2login.PropertyUtils;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler;
@@ -30,7 +31,7 @@ public class CustomLogoutSuccessHandler extends SimpleUrlLogoutSuccessHandler im
 	@Override
 	public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
 	        throws IOException, ServletException {
-		Properties properties = OAuth2BeanFactory.getProperties(OAuth2BeanFactory.getOAuth2PropertiesPath());
+		Properties properties = PropertyUtils.getProperties(PropertyUtils.getOAuth2PropertiesPath());
 		String redirectPath = properties.getProperty("logoutUri");
 		//the redirect path can contain a [token] that should be replaced by the aut token
 		if (StringUtils.isNoneBlank(redirectPath) && redirectPath.contains("[token]")) {

--- a/omod/src/main/java/org/openmrs/module/oauth2login/web/controller/OAuth2BeanFactory.java
+++ b/omod/src/main/java/org/openmrs/module/oauth2login/web/controller/OAuth2BeanFactory.java
@@ -10,20 +10,12 @@
 package org.openmrs.module.oauth2login.web.controller;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Properties;
-import java.util.regex.Pattern;
-import java.util.regex.Matcher;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.openmrs.util.OpenmrsUtil;
+import org.openmrs.module.oauth2login.PropertyUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,51 +34,7 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 public class OAuth2BeanFactory {
 	
-	private static final Pattern ENV_PATTERN = Pattern.compile("\\$\\{([^}]+)}");
-	
 	protected static final Log LOG = LogFactory.getLog(OAuth2BeanFactory.class);
-	
-	public static Properties getProperties(Path path) throws IOException {
-		Properties props = new Properties();
-		try (InputStream inputStream = Files.newInputStream(path)) {
-			props.load(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
-			for (String key : props.stringPropertyNames()) {
-				String value = props.getProperty(key);
-				props.setProperty(key, resolveEnvVariables(value));
-			}
-		}
-		return props;
-	}
-	
-	/**
-	 * Resolves environment variables in the given string.
-	 * <p>
-	 * This method searches for placeholders in the format ${ENV_VAR} within the input string and
-	 * replaces them with the corresponding environment variable values. It first checks system
-	 * properties and then environment variables for the value of each placeholder.
-	 * 
-	 * @param value the input string containing placeholders for environment variables
-	 * @return the input string with all environment variables resolved
-	 */
-	public static String resolveEnvVariables(String value) {
-		Matcher matcher = ENV_PATTERN.matcher(value);
-		StringBuffer buffer = new StringBuffer();
-		while (matcher.find()) {
-			String envVar = matcher.group(1);
-			String envValue = System.getProperty(envVar, System.getenv(envVar));
-			matcher.appendReplacement(buffer, Matcher.quoteReplacement(envValue != null ? envValue : matcher.group(0)));
-		}
-		matcher.appendTail(buffer);
-		return buffer.toString();
-	}
-	
-	public static Path getOAuth2PropertiesPath() {
-		Path path = Paths.get(OpenmrsUtil.getApplicationDataDirectory(), "oauth2.properties");
-		if (!path.toFile().exists()) {
-			LOG.error("the property file doesn't exist " + path.toAbsolutePath());
-		}
-		return path;
-	}
 	
 	/**
 	 * Accessor to the properties files that contains the OAuth 2 client configuration: - client ID
@@ -94,7 +42,7 @@ public class OAuth2BeanFactory {
 	 */
 	@Bean(name = "oauth2.properties")
 	public Properties getOAuth2Properties() throws IOException {
-		return getProperties(getOAuth2PropertiesPath());
+		return PropertyUtils.getOAuth2Properties();
 	}
 	
 	@Bean(name = "oauth2.userInfoUri")

--- a/omod/src/test/java/org/openmrs/module/oauth2login/web/controller/OAuth2IntegrationTest.java
+++ b/omod/src/test/java/org/openmrs/module/oauth2login/web/controller/OAuth2IntegrationTest.java
@@ -36,6 +36,7 @@ import org.openmrs.api.context.Context;
 import org.openmrs.api.context.Credentials;
 import org.openmrs.module.DaemonTokenAware;
 import org.openmrs.module.TestDaemonToken;
+import org.openmrs.module.oauth2login.PropertyUtils;
 import org.openmrs.module.oauth2login.authscheme.OAuth2TokenCredentials;
 import org.openmrs.module.oauth2login.authscheme.UserInfo;
 import org.openmrs.test.BaseModuleContextSensitiveTest;
@@ -107,7 +108,7 @@ public abstract class OAuth2IntegrationTest extends BaseModuleContextSensitiveTe
 	protected Credentials getCredentials() {
 		
 		try {
-			oauth2Props = OAuth2BeanFactory.getProperties(Paths.get(System.getProperty(OPENMRS_APPLICATION_DATA_DIRECTORY),
+			oauth2Props = PropertyUtils.getProperties(Paths.get(System.getProperty(OPENMRS_APPLICATION_DATA_DIRECTORY),
 			    "oauth2.properties"));
 		}
 		catch (IOException e) {


### PR DESCRIPTION
Issue: https://openmrs.atlassian.net/browse/OA-40

This PR adds property `oauth2.enabled` to control starting of the module. It defaults to `true` to ensure backward compatibility if the property is not set. 