### PR TITLE
`Oauth2ExceptionResolver` to return order 50.

### DIFF
--- a/omod/src/main/java/org/openmrs/module/oauth2login/web/Oauth2ExceptionResolver.java
+++ b/omod/src/main/java/org/openmrs/module/oauth2login/web/Oauth2ExceptionResolver.java
@@ -44,4 +44,8 @@ public class Oauth2ExceptionResolver extends SimpleMappingExceptionResolver {
 		return super.resolveException(request, response, handler, ex);
 	}
 	
+	@Override
+	public int getOrder() {
+		return 50;
+	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
 	<organization>
 		<name>OpenMRS</name>
-		<url>http://openmrs.org</url>
+		<url>https://openmrs.org</url>
 	</organization>
 
 	<scm>


### PR DESCRIPTION
add order in Oauth2ExceptionResolver so that UserRedirectRequiredException is caught before openmrs-core SimpleMappingExceptionResolver