### PR TITLE
[Fix] Userinfo can now be parsed even if some of the mapped properties are missing

### DIFF
--- a/api/src/main/java/org/openmrs/module/oauth2login/authscheme/UserInfo.java
+++ b/api/src/main/java/org/openmrs/module/oauth2login/authscheme/UserInfo.java
@@ -23,6 +23,9 @@ import org.slf4j.LoggerFactory;
 
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.DocumentContext;
 
 import net.minidev.json.JSONArray;
 
@@ -55,10 +58,14 @@ public class UserInfo {
 	public static final String PROP_ROLES = MAPPINGS_PFX + "user.roles";
 	
 	public final static String PROP_PROVIDER = MAPPINGS_PFX + "user.provider";
+
+    public final static String PROP_ALLOW_MISSING_PROPERTIES = MAPPINGS_PFX + "allowMissingProperties";
 	
-	private String json; // the user info json
+	private final String json; // the user info json
 	
-	private Properties props;
+	private final Properties props;
+
+    private final Configuration activeConfiguration;
 	
 	/**
 	 * The user info object representation is built from the user info JSON and the OAuth2 mapping
@@ -73,6 +80,12 @@ public class UserInfo {
 	public UserInfo(Properties oauth2Props, String userInfoJson) {
 		this.props = oauth2Props;
 		this.json = userInfoJson;
+		
+		if (props.getProperty(PROP_ALLOW_MISSING_PROPERTIES, "false").equals("true")) {
+			activeConfiguration = Configuration.defaultConfiguration().addOptions(Option.DEFAULT_PATH_LEAF_TO_NULL);
+		} else {
+			activeConfiguration = Configuration.defaultConfiguration();
+		}
 	}
 	
 	@Override
@@ -99,7 +112,8 @@ public class UserInfo {
 		if (props.containsKey(propertyKey)) {
 			String jsonKey = props.getProperty(propertyKey);
 			try {
-				return JsonPath.read(json, "$." + jsonKey);
+				DocumentContext context = JsonPath.using(activeConfiguration).parse(json);
+				return context.read("$." + jsonKey);
 			}
 			catch (PathNotFoundException e) {
 				throw new PathNotFoundException("There was an error when reading the JSON path $." + jsonKey

--- a/omod/src/main/java/org/openmrs/module/oauth2login/web/controller/OAuth2LoginController.java
+++ b/omod/src/main/java/org/openmrs/module/oauth2login/web/controller/OAuth2LoginController.java
@@ -25,7 +25,7 @@ import org.openmrs.api.PersonService;
 import org.openmrs.api.ProviderService;
 import org.openmrs.api.UserService;
 import org.openmrs.api.context.Context;
-import org.openmrs.api.context.ContextAuthenticationException;
+import org.openmrs.api.ValidationException;
 import org.openmrs.module.oauth2login.OAuth2LoginConstants;
 import org.openmrs.module.oauth2login.authscheme.OAuth2TokenCredentials;
 import org.openmrs.module.oauth2login.authscheme.UserInfo;
@@ -36,8 +36,10 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.OAuth2RestOperations;
+import org.springframework.security.oauth2.client.resource.OAuth2AccessDeniedException;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.servlet.ModelAndView;
 
@@ -89,6 +91,14 @@ public class OAuth2LoginController {
 		catch (URISyntaxException e) {
 			throw new RuntimeException(e);
 		}
+        catch (OAuth2AccessDeniedException e) {
+            log.debug("OAuth2AccessDeniedException: " + e.getMessage());
+            Throwable cause = e.getCause();
+            if (cause instanceof ResourceAccessException) {
+                log.debug("ResourceAccessException: " + cause.getMessage());
+            }
+            throw e;
+        }
 		
 		final UserInfo userInfo = new UserInfo(oauth2Props, userInfoJson);
 		try {
@@ -105,13 +115,19 @@ public class OAuth2LoginController {
 				}
 			}
 		}
-		catch (ContextAuthenticationException e) {
-			log.warn("The user '" + userInfo + "' could not be authenticated with the identity provider.");
+		catch (Exception e) {
+			log.debug("Exception: ", e);
+			Throwable cause = e.getCause();
+			if (cause instanceof ValidationException) {
+				log.warn("The user '" + userInfo
+				        + "' was authenticated with the identity provider but could not be created in Openmrs.");
+				log.info("ValidationException: " + cause.getMessage());
+			} else {
+                log.warn("The user '" + userInfo + "' could not be authenticated with the identity provider.");
+            }
 			throw e;
 		}
-		finally {
-			log.info("The user '" + userInfo + "' was successfully authenticated with the identity provider.");
-		}
+		log.info("The user '" + userInfo + "' was successfully authenticated with the identity provider.");
 		
 		return new ModelAndView("redirect:" + getRedirectUri());
 	}


### PR DESCRIPTION
Userinfo can now be parsed even if some of the mapped properties are missing in the json received from keycloak. This functionality can be enabled/disabled with a property.

Also the flow around login has been changed a bit to better log cases where the user is authenticated but couldn't be created in Openmrs.